### PR TITLE
Removing the 'Fibers' package which causes errors during initial setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,12 +70,12 @@
     "deepmerge": "^4.0.0",
     "eslint": "^5.16.0",
     "eslint-plugin-vue": "^5.0.0",
-    "fibers": "^4.0.1",
     "sass": "^1.22.12",
     "sass-loader": "^7.1.0",
     "typescript": "^3.9.7",
     "vue-cli-plugin-vuetify": "^0.6.3",
     "vue-template-compiler": "^2.5.21",
     "vuetify-loader": "^1.2.2"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
During initial setup, I was hitting numerous problems with the initial yarn setup for installing dependent packages. Every time it tried to do the Fibers package, I would get an EINVAL spawn exception. This appears related to a recent CVE that was resolved in April 2024.

Since Fibers is no longer being updated, it does not have a newer version that resolves the spawn issue (from what I can tell). I have removed the Fibers reference for now as it resolves the package installation.